### PR TITLE
Support emitting modules into a subdirectory

### DIFF
--- a/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
@@ -46,6 +46,10 @@ private[linker] object NodeFS {
     val recursive: Boolean = true
   }
 
+  object RmOpt extends js.Object {
+    val recursive: Boolean = true
+  }
+
   trait Stats extends js.Object {
     val mtime: js.UndefOr[js.Date]
     def isDirectory(): Boolean
@@ -92,7 +96,7 @@ private[linker] object NodeFS {
 
   @JSImport("fs")
   @js.native
-  def unlink(path: String, cb: CB[Unit]): Unit = js.native
+  def rm(path: String, opt: RmOpt.type, cb: CB[Unit]): Unit = js.native
 
   // todo check which versions of node need to be supported; I believe this only works with node >= 10
   @JSImport("fs")

--- a/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
@@ -42,6 +42,10 @@ private[linker] object NodeFS {
     val withFileTypes: Boolean = true
   }
 
+  object MkDirOpt extends js.Object {
+    val recursive: Boolean = true
+  }
+
   trait Stats extends js.Object {
     val mtime: js.UndefOr[js.Date]
     def isDirectory(): Boolean
@@ -89,6 +93,11 @@ private[linker] object NodeFS {
   @JSImport("fs")
   @js.native
   def unlink(path: String, cb: CB[Unit]): Unit = js.native
+
+  // todo check which versions of node need to be supported; I believe this only works with node >= 10
+  @JSImport("fs")
+  @js.native
+  def mkdir(path: String, opts: MkDirOpt.type, cb: CB[Unit]): Unit = js.native
 
   @JSImport("path")
   @js.native

--- a/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
@@ -13,13 +13,11 @@
 package org.scalajs.linker
 
 import scala.concurrent._
-
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 import scala.scalajs.js.typedarray.TypedArrayBufferOps._
-
 import java.nio.ByteBuffer
-
+import org.scalajs.linker.NodeFS.MkDirOpt
 import org.scalajs.linker.interface.OutputDirectory
 import org.scalajs.linker.interface.unstable.OutputDirectoryImpl
 
@@ -42,7 +40,13 @@ object NodeOutputDirectory {
         }
       }
 
-      cbFuture[Unit](NodeFS.writeFile(path, data, _))
+      cbFuture[Unit] {
+        val writeDirectory = NodeFS.dirname(path)
+        NodeFS.mkdir(writeDirectory, MkDirOpt, _)
+      }.flatMap(_ =>
+        cbFuture[Unit] {
+          NodeFS.writeFile(path, data, _)
+        })
     }
 
     def readFull(name: String)(

--- a/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
@@ -17,7 +17,7 @@ import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 import scala.scalajs.js.typedarray.TypedArrayBufferOps._
 import java.nio.ByteBuffer
-import org.scalajs.linker.NodeFS.MkDirOpt
+import org.scalajs.linker.NodeFS.{MkDirOpt, RmOpt}
 import org.scalajs.linker.interface.OutputDirectory
 import org.scalajs.linker.interface.unstable.OutputDirectoryImpl
 
@@ -60,7 +60,7 @@ object NodeOutputDirectory {
       cbFuture[js.Array[String]](NodeFS.readdir(directory, _)).map(_.toList)
 
     def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] =
-      cbFuture[Unit](NodeFS.unlink(getPath(name), _))
+      cbFuture[Unit](NodeFS.rm(getPath(name), RmOpt, _))
 
     private def getPath(name: String) = NodeFS.join(directory, name)
   }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
@@ -61,18 +61,38 @@ object PathOutputDirectory {
     def readFull(name: String)(implicit ec: ExecutionContext): Future[ByteBuffer] =
       withChannel(getPath(name), StandardOpenOption.READ)(readFromChannel(_))
 
-    def listFiles()(implicit ec: ExecutionContext): Future[List[String]] = Future {
+    override def listFiles()(implicit ec: ExecutionContext): Future[List[String]] =
+      listFilesImpl(directory, e => directory.relativize(e).toString)
+
+    private def listFilesImpl[B](
+        d: Path,
+        transform: Path => B
+    )(implicit ec: ExecutionContext): Future[List[B]] = Future {
       blocking {
-        val builder = List.newBuilder[String]
-        Files.list(directory).forEachOrdered { entry =>
-          builder += directory.relativize(entry).toString()
+        val builder = List.newBuilder[B]
+        Files.list(d).forEachOrdered { entry =>
+          builder += transform(entry)
         }
         builder.result()
       }
     }
 
-    def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] =
-      Future(blocking(Files.delete(getPath(name))))
+    def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] = {
+      def deleteFile(path: Path): Future[Unit] =
+        Future(blocking(Files.delete(path)))
+      def deleteRecursively(path: Path):Future[Unit] = if (Files.isDirectory(path)) {
+        for {
+          files <- listFilesImpl(path, identity)
+          _ <- Future.sequence(files.map(deleteRecursively))
+          _ <- deleteFile(path)
+        }
+          yield ()
+      } else {
+        deleteFile(path)
+      }
+
+      deleteRecursively(getPath(name))
+    }
 
     private def getPath(name: String) = directory.resolve(name)
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
@@ -83,7 +83,12 @@ object PathOutputDirectory {
 
       val tmpFileFuture = Future {
         blocking {
-          val tmpFile = Files.createTempFile(directory, ".tmp-" + name, ".tmp")
+          val fullPath = directory.resolve(Paths.get(name))
+          val resolvedDirectory = fullPath.getParent
+          val resolvedName = fullPath.getFileName.toString
+          Files.createDirectories(resolvedDirectory)
+
+          val tmpFile = Files.createTempFile(resolvedDirectory, ".tmp-" + resolvedName, ".tmp")
 
           /* Set file permissions for temporary file as in Linux it is created
            * with permissions 0600 which deviates from the standard 0644 used


### PR DESCRIPTION
WIP:
- tests need to be updated
- cleanup/code style needs to be fixed
- Not all `OutputDirectoryImpl` implementations have been modified; notably missing `MemOutputDirectory` and co.

---
Also needs a PR back to main scala-js repo